### PR TITLE
Add --no-animation flag to disable spinner icon animation

### DIFF
--- a/bin/claude-depester
+++ b/bin/claude-depester
@@ -368,23 +368,32 @@ async function main() {
     let failCount = 0;
     
     for (const inst of installations) {
-      const success = restoreBackup(inst.path);
       if (installations.length > 1) {
         log(`${inst.method}:`);
         log(`  ${inst.path}`);
       }
-      if (success) {
-        if (installations.length > 1) {
-          log('  -> Restored from backup\n');
+      try {
+        const success = restoreBackup(inst.path);
+        if (success) {
+          if (installations.length > 1) {
+            log('  -> Restored from backup\n');
+          } else {
+            log('Restored original file from backup.');
+          }
+          successCount++;
         } else {
-          log('Restored original file from backup.');
+          if (installations.length > 1) {
+            log('  -> No backup found\n');
+          } else {
+            error('No backup found. Cannot restore.');
+          }
+          failCount++;
         }
-        successCount++;
-      } else {
+      } catch (err) {
         if (installations.length > 1) {
-          log('  -> No backup found\n');
+          log(`  -> Failed: ${err.message}\n`);
         } else {
-          error('No backup found. Cannot restore.');
+          error(`Failed to restore: ${err.message}`);
         }
         failCount++;
       }

--- a/bin/claude-depester
+++ b/bin/claude-depester
@@ -30,6 +30,7 @@ const flags = {
   debug: args.includes('--debug') || args.includes('-d'),
   log: args.includes('--log'),
   list: args.includes('--list') || args.includes('-l'),
+  noAnimation: args.includes('--no-animation'),
   // --all is accepted silently for backwards compatibility (all is now the default)
 };
 
@@ -58,6 +59,9 @@ function formatPatchDetails(result) {
   if (result.completionCount > 0) {
     parts.push(`completion(${result.completionCount})`);
   }
+  if (result.animationCount > 0) {
+    parts.push(`animation(${result.animationCount})`);
+  }
   return parts.length > 0 ? ` [${parts.join(' + ')}]` : '';
 }
 
@@ -77,12 +81,13 @@ OPTIONS:
   -c, --check       Check patch status of all installations
   -r, --restore     Restore all installations from backup
   -n, --dry-run     Preview changes without applying
+  --no-animation    Also disable the animated spinner icon (webview only)
   --path <file>     Target a specific file instead of auto-detecting
-  
+
   --install-hook    Add SessionStart hook (auto-patch after updates)
   --remove-hook     Remove SessionStart hook
   --hook-status     Check if hook is installed
-  
+
   -s, --silent      Suppress output (for hook use)
   --verbose         Show detailed information
   -d, --debug       Show detailed debug info (for troubleshooting)
@@ -409,7 +414,7 @@ async function main() {
     
     const debugBefore = flags.log ? getDebugInfo(inst.path, { type: inst.type }) : null;
     
-    const result = patch(inst.path, { dryRun: flags.dryRun, type: inst.type });
+    const result = patch(inst.path, { dryRun: flags.dryRun, type: inst.type, noAnimation: flags.noAnimation });
     if (result.success) {
       if (result.alreadyPatched) {
         if (installations.length > 1 || flags.verbose) {

--- a/lib/patcher.js
+++ b/lib/patcher.js
@@ -39,6 +39,12 @@ const COMPLETION_VERBS = [
 // What to replace completion verbs with
 const COMPLETION_REPLACEMENT = 'Thought';
 
+// Spinner icon characters (animated cycling icon next to thinking text in webview)
+// These cycle every 120ms: ["·","✢","*","✶","✻","✽"] bouncing back and forth
+const SPINNER_ICON_CHARS = ['·', '✢', '*', '✶', '✻', '✽'];
+// Static replacement - single dot, no animation
+const STATIC_ICON_CHAR = '·';
+
 /**
  * Check if content contains the silly words array (spinner or completion)
  * @param {string|Buffer} content - File content
@@ -225,56 +231,72 @@ function patchBinaryContent(buffer) {
  * @param {Buffer} jsContent - JavaScript content as buffer
  * @param {object} options - Options
  * @param {boolean} options.isWebview - Whether this is a webview file (uses different var names)
- * @returns {{ patched: Buffer, count: number, spinnerCount: number, completionCount: number } | null}
+ * @param {boolean} options.noAnimation - Whether to also disable the spinner icon animation
+ * @returns {{ patched: Buffer, count: number, spinnerCount: number, completionCount: number, animationCount: number } | null}
  */
 function patchJsContent(jsContent, options = {}) {
   let str = jsContent.toString('utf-8');
-  
+
   // Generic pattern to match any string array assignment: varName=["str","str"...]
   // Capture group 1: varName
   // Capture group 2: array content including brackets
   const arrayPattern = /([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=\s*(\[[^\]]+\])/g;
-  
+
   let spinnerCount = 0;
   let completionCount = 0;
-  
+  let animationCount = 0;
+
   str = str.replace(arrayPattern, (match, varName, arrayContent) => {
     // Check for spinner words in this array
     let markerCount = 0;
     for (const marker of MARKER_WORDS) {
       if (arrayContent.includes(`"${marker}"`)) markerCount++;
     }
-    
+
     // If we found enough marker words, this is the spinner array
     if (markerCount >= 3) {
       spinnerCount++;
       return `${varName}=["${REPLACEMENT_WORD}"]`;
     }
-    
+
     // Check for completion verbs in this array
     // (Only exists in the binary, not in the webview)
     let completionMarkerCount = 0;
     for (const verb of COMPLETION_VERBS) {
       if (arrayContent.includes(`"${verb}"`)) completionMarkerCount++;
     }
-    
+
     // If we found enough completion verbs, this is the completion array
     if (completionMarkerCount >= 3) {
       completionCount++;
       return `${varName}=["${COMPLETION_REPLACEMENT}"]`;
     }
-    
+
+    // Check for spinner icon characters array (webview only)
+    if (options.noAnimation) {
+      let iconCharCount = 0;
+      for (const ch of SPINNER_ICON_CHARS) {
+        if (arrayContent.includes(`"${ch}"`)) iconCharCount++;
+      }
+      // Need most of the icon chars to match (avoid false positives)
+      if (iconCharCount >= 4) {
+        animationCount++;
+        return `${varName}=["${STATIC_ICON_CHAR}"]`;
+      }
+    }
+
     return match;
   });
-  
-  const count = spinnerCount + completionCount;
+
+  const count = spinnerCount + completionCount + animationCount;
   if (count === 0) return null;
-  
+
   return {
     patched: Buffer.from(str, 'utf-8'),
     count,
     spinnerCount,
-    completionCount
+    completionCount,
+    animationCount
   };
 }
 
@@ -352,6 +374,29 @@ function isNativeBinary(filePath) {
 }
 
 /**
+ * Check if content contains the spinner icon animation characters
+ * @param {string|Buffer} content - File content
+ * @returns {boolean}
+ */
+function hasSpinnerIconAnimation(content) {
+  const str = Buffer.isBuffer(content) ? content.toString('utf-8') : content;
+  let found = 0;
+  for (const ch of SPINNER_ICON_CHARS) {
+    if (str.includes(`"${ch}"`)) found++;
+  }
+  return found >= 4;
+}
+
+/**
+ * Check if spinner icon animation is already patched (replaced with single static char)
+ * @param {string|Buffer} content - File content
+ * @returns {boolean}
+ */
+function isAnimationPatched(content) {
+  return !hasSpinnerIconAnimation(content);
+}
+
+/**
  * Format patch result message with details
  * @param {object} result - Result from patchJsContent
  * @param {string} fileType - Type of file (binary, webview, JavaScript)
@@ -360,17 +405,20 @@ function isNativeBinary(filePath) {
  */
 function formatPatchMessage(result, fileType, isDryRun) {
   const parts = [];
-  
+
   if (result.spinnerCount > 0) {
     parts.push(`spinner words (${result.spinnerCount})`);
   }
   if (result.completionCount > 0) {
     parts.push(`completion verbs (${result.completionCount})`);
   }
-  
+  if (result.animationCount > 0) {
+    parts.push(`spinner animation (${result.animationCount})`);
+  }
+
   const what = parts.join(' + ');
   const prefix = isDryRun ? 'Dry run - would patch' : 'Patched';
-  
+
   return `${prefix} ${what} in ${fileType}`;
 }
 
@@ -380,10 +428,11 @@ function formatPatchMessage(result, fileType, isDryRun) {
  * @param {object} options - Options
  * @param {boolean} options.dryRun - Don't actually patch
  * @param {string} options.type - Override type detection: 'binary', 'js', 'webview'
- * @returns {{ success: boolean, message: string, alreadyPatched?: boolean, spinnerCount?: number, completionCount?: number }}
+ * @param {boolean} options.noAnimation - Disable spinner icon animation (webview only)
+ * @returns {{ success: boolean, message: string, alreadyPatched?: boolean, spinnerCount?: number, completionCount?: number, animationCount?: number }}
  */
 function patch(filePath, options = {}) {
-  const { dryRun = false, type } = options;
+  const { dryRun = false, type, noAnimation = false } = options;
   
   try {
     // Always verify with isNativeBinary() - detector may misclassify npm installs as binaries
@@ -445,74 +494,81 @@ function patch(filePath, options = {}) {
           message: formatPatchMessage(result, 'binary', true),
           dryRun: true,
           spinnerCount: result.spinnerCount,
-          completionCount: result.completionCount
+          completionCount: result.completionCount,
+          animationCount: result.animationCount || 0
         };
       }
-      
+
       // Create backup
       const backupPath = createBackup(filePath);
-      
+
       // Repack binary with patched JS
       repackNativeInstallation(filePath, result.patched, filePath, targetModuleName, targetType);
-      
+
       return {
         success: true,
         message: `${formatPatchMessage(result, 'binary', false)}. Backup at: ${backupPath}`,
         backupPath,
         spinnerCount: result.spinnerCount,
-        completionCount: result.completionCount
+        completionCount: result.completionCount,
+        animationCount: result.animationCount || 0
       };
       
     } else {
       // Plain JS file (npm installation) or webview file
       const content = fs.readFileSync(filePath);
       const fileType = isWebview ? 'webview' : 'JavaScript';
-      
-      if (isPatched(content)) {
+
+      const wordsPatched = isPatched(content);
+      const animPatched = !noAnimation || isAnimationPatched(content);
+
+      if (wordsPatched && animPatched) {
         return {
           success: true,
           message: 'Already patched',
           alreadyPatched: true
         };
       }
-      
-      if (!hasSillyWords(content)) {
+
+      if (!wordsPatched && !hasSillyWords(content)) {
         return {
           success: false,
           message: `Could not find silly words array in ${fileType}. Claude Code version may not be supported.`
         };
       }
-      
-      const result = patchJsContent(content, { isWebview });
+
+      const result = patchJsContent(content, { isWebview, noAnimation });
       if (!result) {
         return {
           success: false,
           message: `Could not locate words array pattern in ${fileType}`
         };
       }
-      
+
       if (dryRun) {
         return {
           success: true,
           message: formatPatchMessage(result, fileType, true),
           dryRun: true,
           spinnerCount: result.spinnerCount,
-          completionCount: result.completionCount
+          completionCount: result.completionCount,
+          animationCount: result.animationCount
         };
       }
-      
+
       // Create backup
       const backupPath = createBackup(filePath);
-      
+
       // Write patched content
       fs.writeFileSync(filePath, result.patched);
-      
+
       return {
         success: true,
         message: `${formatPatchMessage(result, fileType, false)}. Backup at: ${backupPath}`,
         backupPath,
         spinnerCount: result.spinnerCount,
-        completionCount: result.completionCount
+        completionCount: result.completionCount,
+        animationCount: result.animationCount
       };
     }
     
@@ -565,7 +621,9 @@ function checkStatus(filePath, options = {}) {
       isBinary,
       isWebview,
       completionPatched: isCompletionPatched(content),
-      hasCompletionVerbs: hasCompletionVerbs(content)
+      hasCompletionVerbs: hasCompletionVerbs(content),
+      animationPatched: isAnimationPatched(content),
+      hasSpinnerIconAnimation: hasSpinnerIconAnimation(content)
     };
   } catch (err) {
     return {
@@ -603,6 +661,9 @@ function getDebugInfo(filePath, options = {}) {
     hasOriginalCompletionArray: false, // ["Baked"..."Worked"]
     markerWordsFound: [],
     completionVerbsFound: [],
+    // Spinner icon animation
+    hasSpinnerIconAnimation: false,
+    animationPatched: false,
     // Computed status
     spinnerPatched: false,
     completionPatched: false,
@@ -674,7 +735,9 @@ function getDebugInfo(filePath, options = {}) {
     debug.spinnerPatched = isPatched(content);
     debug.completionPatched = isCompletionPatched(content);
     debug.hasSillyWords = hasSillyWords(content);
-    
+    debug.hasSpinnerIconAnimation = hasSpinnerIconAnimation(content);
+    debug.animationPatched = isAnimationPatched(content);
+
   } catch (err) {
     debug.error = err.message;
   }
@@ -690,11 +753,15 @@ module.exports = {
   hasBackup,
   hasSillyWords,
   hasCompletionVerbs,
+  hasSpinnerIconAnimation,
   isPatched,
   isCompletionPatched,
+  isAnimationPatched,
   isNativeBinary,
   MARKER_WORDS,
   REPLACEMENT_WORD,
   COMPLETION_VERBS,
-  COMPLETION_REPLACEMENT
+  COMPLETION_REPLACEMENT,
+  SPINNER_ICON_CHARS,
+  STATIC_ICON_CHAR
 };


### PR DESCRIPTION
## Summary
- Adds `--no-animation` flag that replaces the cycling animated icon characters (`·`, `✢`, `*`, `✶`, `✻`, `✽`) with a single static `·` in VS Code extension webviews
- Patches both spinner icon arrays found in the webview (main thinking spinner + secondary)
- Fully integrated with existing `--dry-run`, `--check`, and `--restore` workflows
- Fixes `--restore` crashing when a file is locked by a running process (e.g. `claude.exe` while VS Code is open)

## Test plan
- [x] `npx claude-depester --no-animation --dry-run` shows animation patches would be applied
- [x] `npx claude-depester --no-animation` patches webview successfully
- [x] Reload VS Code — spinner icon is now a static `·` instead of cycling characters
- [x] `npx claude-depester --restore` restores original animation and continues past locked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)